### PR TITLE
Cap "types" to 256, correctly render "types" 65-256 when using palette dependent shader

### DIFF
--- a/src/main/java/com/particle_life/app/Main.java
+++ b/src/main/java/com/particle_life/app/Main.java
@@ -365,7 +365,7 @@ public class Main extends App {
                         // NTYPES
                         ImInt matrixSizeInput = new ImInt(settings.matrix.size());
                         if (ImGui.inputInt("types", matrixSizeInput, 1, 1, ImGuiInputTextFlags.EnterReturnsTrue)) {
-                            final int newSize = Math.max(1, matrixSizeInput.get());
+                            final int newSize = Math.max(1, Math.min(matrixSizeInput.get(), 256));
                             loop.enqueue(() -> physics.setMatrixSize(newSize));
                         }
 

--- a/src/main/resources/shaders/default.vert
+++ b/src/main/resources/shaders/default.vert
@@ -1,6 +1,6 @@
 #version 410
 
-uniform vec4 palette[64];
+uniform vec4 palette[256];
 uniform float time;
 uniform mat4 transform;
 

--- a/src/main/resources/shaders/old.vert
+++ b/src/main/resources/shaders/old.vert
@@ -5,7 +5,7 @@
 //layout(location = 1) in int type;
 
 uniform float time = 0.0;
-uniform vec4 palette[64];
+uniform vec4 palette[256];
 uniform int paletteSize;
 
 in int type;

--- a/src/main/resources/shaders/speed.vert
+++ b/src/main/resources/shaders/speed.vert
@@ -2,7 +2,7 @@
 
 #define FACTOR 10
 
-uniform vec4 palette[64];
+uniform vec4 palette[256];
 uniform float time = 0.0;
 uniform mat4 transform;
 

--- a/src/main/resources/shaders/speed_fade.vert
+++ b/src/main/resources/shaders/speed_fade.vert
@@ -2,7 +2,7 @@
 
 #define FACTOR 10
 
-uniform vec4 palette[64];
+uniform vec4 palette[256];
 uniform float time = 0.0;
 uniform mat4 transform;
 

--- a/src/main/resources/shaders/white.vert
+++ b/src/main/resources/shaders/white.vert
@@ -2,7 +2,7 @@
 
 #define FACTOR 10
 
-uniform vec4 palette[64];
+uniform vec4 palette[256];
 uniform float time = 0.0;
 uniform mat4 transform;
 


### PR DESCRIPTION
Quick fix to cap the maximum type selection to 256. When testing out higher type values I noticed that any type 65+ was not being drawn with the default shader but would show up fine with the white one. 
Bumped the palette sizes on all palette shaders (even the white one for consistency) as a fix.

References tom-mohr/particle-life-app#11

![before](https://user-images.githubusercontent.com/36338176/217340629-55bf45b9-3de4-405c-a237-dde02471f333.png)
![after](https://user-images.githubusercontent.com/36338176/217340678-446e20a4-71fc-4533-987d-892d8f9313af.png)
